### PR TITLE
Updated for FVTT v 0.8.8.

### DIFF
--- a/copy-chat/main.js
+++ b/copy-chat/main.js
@@ -10,6 +10,7 @@ Hooks.on("ready", function() {
              //console.log($(event.target));
              let content = $(this).closest(".chat-message").text().replace(/\s+/g, " ");
              //console.log(content);
+             content = content.trim();
              copyToClipboard(content);
              ui.notifications.notify("Copied to clipboard");
          }

--- a/copy-chat/main.js
+++ b/copy-chat/main.js
@@ -10,7 +10,7 @@ Hooks.on("ready", function() {
              //console.log($(event.target));
              let content = $(this).closest(".chat-message").text().replace(/\s+/g, " ");
              //console.log(content);
-             content = content.trim();
+             content.trim();
              copyToClipboard(content);
              ui.notifications.notify("Copied to clipboard");
          }

--- a/copy-chat/main.js
+++ b/copy-chat/main.js
@@ -10,8 +10,7 @@ Hooks.on("ready", function() {
              //console.log($(event.target));
              let content = $(this).closest(".chat-message").text().replace(/\s+/g, " ");
              //console.log(content);
-             content.trim();
-             copyToClipboard(content);
+             copyToClipboard(content.trim());
              ui.notifications.notify("Copied to clipboard");
          }
     });

--- a/copy-chat/module.json
+++ b/copy-chat/module.json
@@ -2,9 +2,9 @@
 	"name": "copy-chat",
 	"title": "Copy Chat",
 	"description": "Adds the ability to copy text from the chat window to your local clipboard",
-	"version": "1.0",
+	"version": "1.1",
 	"minimumCoreVersion" : "0.7.0",
-	"compatibleCoreVersion" : "0.7.0",
+	"compatibleCoreVersion" : "0.8.8",
 	"author": "Ape-Fink",
 	"esmodules": [
 		"./main.js"


### PR DESCRIPTION
I updated the code for FVTT v0.8.8.
I know it works for at least v0.8.5.
Added a ".trim()" to the input of the text being copied. (I didn't like the spaces between the text.)

I am going to add the Discord ":game_die:" for pasting rolls into Discord chat, future version.... (So you know it is a dice roll in Discord.)
This will only work if the icon for the dice is in the FVTT chat window. ("fa-dice" is the CSS class name it will be looking for.)